### PR TITLE
fix error in Send-DatadogEvent, correct Readme.md

### DIFF
--- a/Functions/Send-DatadogEvent.ps1
+++ b/Functions/Send-DatadogEvent.ps1
@@ -9,19 +9,18 @@
 #>
 
 function Send-DatadogEvent {
-  param(
-      [Parameter(Mandatory=$false)]
-      [string]$Api_Key = $env:Datadog_API_Key,
-      [string]$Title,
-      [string]$Message,
-      [ValidateSet("Normal","Low")]
-      [string]$Priority = "Normal",
-      [string]$Tags,
-      [ValidateSet("Error","Warning","Success","Info")]
-      [string]$Type = "Info"
-
-  )
-
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Api_Key = $env:Datadog_API_Key,
+        [string]$Title,
+        [string]$Message,
+        [ValidateSet("Normal", "Low")]
+        [string]$Priority = "Normal",
+        [string]$Tags = "`"created-by:powershell.posh-datadog`"", # needs a default tag if no -tags $tags specified
+        [ValidateSet("Error", "Warning", "Success", "Info")]
+        [string]$Type = "Info"
+    )
+    Write-Warning "Sending $Priority priority $Type Event:$Title Message:$Message"
     $Body = @"
     {
           "title": "$Title",
@@ -37,7 +36,6 @@ function Send-DatadogEvent {
     # debug
     # $jsonObject = $Body | ConvertFrom-Json
 
-    $results = Invoke-RestMethod -Uri $url -Body $Body -Method Post
-    $results = $results | ConvertFrom-Json | Select-Object -ExpandProperty event
+    $results = Invoke-RestMethod -Uri $url -Body $Body -Method Post -ContentType application/json
     $results
 }

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
-Posh-Datadog module
-===================
+# Posh-Datadog module
 
 [![Build status](https://ci.appveyor.com/api/projects/status/cilr6ssa6agsm0ct?svg=true)](https://ci.appveyor.com/project/sbe-arg/posh-datadog)
 
 ## To test/debug:
+
 Download module -> run Posh-Datadog.sandbox.ps1 to load.
 
 ## Install via PowershellLibrary
+
 ```powershell
 PowerShellGet\Install-Module Posh-Datadog -Scope CurrentUser
 ```
+
 ### Or install/update via PsGet
+
 ```powershell
 psget\Install-Module -ModuleUrl https://github.com/sbe-arg/Posh-Datadog/archive/master.zip # -update
 ```
 
 ## cmdlets
+
 ```powershell
 # Query events stream:
 Get-DatadogEvent -Filter "from-text-in-monitor" -Tags "tag1:value1" -Sources "alert" -Time [int]inseconds
@@ -37,10 +41,14 @@ Set-DatadogUser -SetRole "adm,ro,st"
 Set-DatadogUser -SetName "sting"
 Set-DatadogUser -SetEmail "string"
 # Metrics:
-$Tags = @("creator:$env:USERNAME","host:$env:COMPUTERNAME")
+$Tags = @("creator:$env:USERNAME","host:$env:COMPUTERNAME") | ConvertTo-JSON
 Send-DatadogMetric -Metric "cool.beans.success" -Value "20" -Tags $Tags
+# or
+Send-DatadogMetric -Metric "cool.beans.success" -Value "20" -Tags "[`"creator:$env:USERNAME`",`"host:$env:COMPUTERNAME`"]"
+
 Send-DatadogStatsD 'my_metric:321|g'
 ```
 
 # Open Source:
+
 I have no affiliation with Datadog, take a copy and do whatever :)


### PR DESCRIPTION
Thanks so much for contributing a library like this!   This change corrects a two issues in Send-DatadogEvent: one where it would create invalid JSON if the -Tags property wasn't specified, and one where it was trying to convert the response from datadog into json and creating an error.  

It also updates the readme which incorrectly suggested passing an array into the -Tags property, which will cause an error.  Honestly I like the idea of it taking an array, rather than a JSON string - seems more ergonomic and prevents the user from inadvertently malforming the json payload that is sent to datadog.  That and it every other datadog library I've worked with takes an array for tags.  That being said, I made no changes to the behavior of -Tags.